### PR TITLE
Implement clock abstraction

### DIFF
--- a/clock/clock.go
+++ b/clock/clock.go
@@ -1,0 +1,33 @@
+package clock
+
+import "time"
+
+// Clock defines an API for accessing the current time and for implementing
+// timeouts / timers.
+type Clock interface {
+	// Now returns the current time.
+	Now() time.Time
+
+	// After waits for the duration to elapse and then sends the current time on
+	// the returned channel.
+	After(time.Duration) <-chan time.Time
+
+	// NewTimer creates a new Timer that will send the current time on its
+	// channel after at least duration d.
+	NewTimer(time.Duration) Timer
+}
+
+// Timer defines an API for accessing a timer obtained via a clock instance.
+type Timer interface {
+	// C returns a channel where the timer will send the current time once it
+	// expires.
+	C() <-chan time.Time
+
+	// Reset the timer to expire after at least duration d.
+	Reset(time.Duration)
+
+	// Stop the timer from firing. It returns true if the timer was active and
+	// false otherwise. if Stop returns false, the caller must first drain the
+	// channel channel before calling Reset().
+	Stop() bool
+}

--- a/clock/fake.go
+++ b/clock/fake.go
@@ -1,0 +1,158 @@
+package clock
+
+import (
+	"sync"
+	"time"
+)
+
+var _ Clock = (*FakeClock)(nil)
+
+type waiter struct {
+	timeout  time.Duration
+	notifyCh chan time.Time
+
+	// Set to true when the channel for this waiter has been returned to the
+	// timeout/timer consumer.
+	consumerWaiting bool
+}
+
+// FakeClock is a clock implementation that allows time to be programmatically
+// advanced via calls to its Advance/WaitAdvance methods. It is meant to be
+// used as a drop-in replacement for the wall clock in tests.
+type FakeClock struct {
+	mu      sync.Mutex
+	waiters []*waiter
+	curTime time.Time
+}
+
+// NewFakeClock creates a new fake clock instance whose time is set to curTime.
+func NewFakeClock(curTime time.Time) *FakeClock {
+	return &FakeClock{curTime: curTime}
+}
+
+// Now returns the current time.
+func (fc *FakeClock) Now() time.Time {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	return fc.curTime
+}
+
+// After waits for the duration to elapse and then sends the current time on
+// the returned channel.
+func (fc *FakeClock) After(d time.Duration) <-chan time.Time {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	waiter := makeWaiter(d, true)
+	fc.waiters = append(fc.waiters, waiter)
+	return waiter.notifyCh
+}
+
+// NewTimer creates a new Timer that will send the current time on its
+// channel after at least duration d.
+func (fc *FakeClock) NewTimer(d time.Duration) Timer {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	// Timers are similar to waiters with the exception that the consumerWaiting
+	// flag will only be set once the timer's C() method has been invoked.
+	waiter := makeWaiter(d, false)
+	fc.waiters = append(fc.waiters, waiter)
+	return fakeClockTimer{fc: fc, waiter: waiter}
+}
+
+// WaitAdvance blocks until at least the requested number of waiters has
+// received back a timeout/timer channel from the clock and then advances the
+// clock by d.
+func (fc *FakeClock) WaitAdvance(numWaiters int, d time.Duration) {
+	for {
+		fc.mu.Lock()
+		var waitingConsumers int
+		for _, w := range fc.waiters {
+			if w.consumerWaiting {
+				waitingConsumers++
+			}
+
+			if waitingConsumers == numWaiters {
+				fc.mu.Unlock()
+				fc.Advance(d)
+				return
+			}
+		}
+		fc.mu.Unlock()
+
+		// Poll a bit later
+		<-time.After(100 * time.Millisecond)
+	}
+}
+
+// Advance the clock by d and handle expired timers/timeouts.
+func (fc *FakeClock) Advance(d time.Duration) {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	fc.curTime.Add(d)
+
+	// Notify and remove expired waiters.
+	var activeWaiters []*waiter
+	for _, waiter := range fc.waiters {
+		if waiter.timeout <= d {
+			waiter.timeout = 0
+			select {
+			case waiter.notifyCh <- fc.curTime:
+			default:
+				// Consumer has not received the last
+				// notification yet.  Drop the new one to the
+				// floor.
+			}
+			continue
+		}
+		waiter.timeout -= d
+		activeWaiters = append(activeWaiters, waiter)
+	}
+	fc.waiters = activeWaiters
+}
+
+func makeWaiter(d time.Duration, consumerWaiting bool) *waiter {
+	return &waiter{
+		timeout:         d,
+		notifyCh:        make(chan time.Time, 1),
+		consumerWaiting: consumerWaiting,
+	}
+}
+
+type fakeClockTimer struct {
+	fc     *FakeClock
+	waiter *waiter
+}
+
+func (ft fakeClockTimer) C() <-chan time.Time {
+	ft.fc.mu.Lock()
+	defer ft.fc.mu.Unlock()
+
+	ft.waiter.consumerWaiting = true
+	return ft.waiter.notifyCh
+}
+
+func (ft fakeClockTimer) Reset(d time.Duration) {
+	ft.fc.mu.Lock()
+	defer ft.fc.mu.Unlock()
+	ft.waiter.timeout = d
+}
+
+func (ft fakeClockTimer) Stop() bool {
+	ft.fc.mu.Lock()
+	defer ft.fc.mu.Unlock()
+
+	alreadyFired := ft.waiter.timeout == 0
+	var activeWaiters []*waiter
+	for _, w := range ft.fc.waiters {
+		if w == ft.waiter {
+			continue
+		}
+		activeWaiters = append(activeWaiters, w)
+	}
+	ft.fc.waiters = activeWaiters
+
+	return alreadyFired
+}

--- a/clock/fake_test.go
+++ b/clock/fake_test.go
@@ -1,0 +1,113 @@
+package clock
+
+import (
+	"time"
+
+	gc "gopkg.in/check.v1"
+)
+
+var _ = gc.Suite(&fakeClockSuite{})
+
+type fakeClockSuite struct {
+}
+
+func (fakeClockSuite) TestGetCurrentTime(c *gc.C) {
+	now := time.Now()
+	clk := NewFakeClock(now)
+	c.Assert(clk.Now(), gc.DeepEquals, now)
+
+	// Advance clock and ensure that the current time gets correctly updated.
+	advance := 90 * time.Second
+	now = now.Add(advance)
+	clk.Advance(advance)
+}
+
+func (fakeClockSuite) TestAdvanceTriggersTimeout(c *gc.C) {
+	clk := NewFakeClock(time.Now())
+
+	timeout1Ch := clk.After(10 * time.Minute)
+	timeout2Ch := clk.After(11 * time.Minute)
+
+	go func() {
+		// This should trigger both timeouts to fire.
+		clk.Advance(11 * time.Minute)
+	}()
+
+	select {
+	case <-timeout1Ch:
+	case <-time.After(3 * time.Second):
+		c.Error("timeout waiting for fake clock to trigger 10 min timeout after async advance")
+	}
+
+	select {
+	case <-timeout2Ch:
+	case <-time.After(3 * time.Second):
+		c.Error("timeout waiting for fake clock to trigger 11 min timeout after async advance")
+	}
+
+	clk.mu.Lock()
+	numWaiters := len(clk.waiters)
+	clk.mu.Unlock()
+	c.Assert(numWaiters, gc.Equals, 0, gc.Commentf("expired waiters were not removed from clock waiter list"))
+}
+
+func (fakeClockSuite) TestTimer(c *gc.C) {
+	clk := NewFakeClock(time.Now())
+	timer := clk.NewTimer(10 * time.Minute)
+
+	// Advance the clock to trigger the timer. Then try to stop the timer
+	// and check that it reports back that it has already fired.
+	clk.Advance(10 * time.Minute)
+	fired := timer.Stop()
+	c.Assert(fired, gc.Equals, true, gc.Commentf("expected Stop() to return true when the timer has already fired"))
+
+	// Dequeue the channel; the notification should have already been
+	// written to it when the timer expired.
+	select {
+	case <-timer.C():
+	case <-time.After(3 * time.Second):
+		c.Error("timeout waiting for timer to publish notification to its channel")
+	}
+
+	// Reset the timer, stop it again and check the reported hasFired status.
+	timer.Reset(5 * time.Minute)
+	fired = timer.Stop()
+	c.Assert(fired, gc.Equals, false, gc.Commentf("expected Stop() to return false when the timer has not yet fired"))
+}
+
+func (fakeClockSuite) TestWaitAdvance(c *gc.C) {
+	clk := NewFakeClock(time.Now())
+
+	advancedCh := make(chan struct{})
+	timeoutCh := clk.After(10 * time.Minute)
+	timer := clk.NewTimer(10 * time.Minute)
+
+	go func() {
+		clk.WaitAdvance(2, 10*time.Minute)
+		close(advancedCh)
+	}()
+
+	// Grab the timers channel so that the clock can detect that two
+	// consumers are waiting on it.
+	timerCh := timer.C()
+
+	// Since both channels (timeout and timer) have been read by us,
+	// the WaitAdvance call in the goroutine should unblock.
+	select {
+	case <-advancedCh:
+	case <-time.After(3 * time.Second):
+		c.Error("timeout waiting for WaitAdvance to return")
+	}
+
+	// A notification should have been enqueued to both channels
+	select {
+	case <-timeoutCh:
+	case <-time.After(3 * time.Second):
+		c.Error("timeout waiting for notification on clock.After() result")
+	}
+	select {
+	case <-timerCh:
+	case <-time.After(3 * time.Second):
+		c.Error("timeout waiting for notification on clock.NewTimer().C() result")
+	}
+}

--- a/clock/package_test.go
+++ b/clock/package_test.go
@@ -1,0 +1,11 @@
+package clock
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/clock/wall.go
+++ b/clock/wall.go
@@ -1,0 +1,29 @@
+package clock
+
+import "time"
+
+// WallClock implements a clock using the time package from the Go standard library.
+var WallClock Clock = wallClock{}
+
+type wallClock struct{}
+
+// Now returns the current time.
+func (wallClock) Now() time.Time { return time.Now() }
+
+// After waits for the duration to elapse and then sends the current time on
+// the returned channel.
+func (wallClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+// NewTimer creates a new Timer that will send the current time on its
+// channel after at least duration d.
+func (wallClock) NewTimer(d time.Duration) Timer {
+	return wallClockTimer{time.NewTimer(d)}
+}
+
+type wallClockTimer struct {
+	t *time.Timer
+}
+
+func (wt wallClockTimer) C() <-chan time.Time   { return wt.t.C }
+func (wt wallClockTimer) Reset(d time.Duration) { _ = wt.t.Reset(d) }
+func (wt wallClockTimer) Stop() bool            { return wt.t.Stop() }


### PR DESCRIPTION
The clock abstraction will be used during testing to ensure that all time-sensitive aspects (e.g. election and heartbeat timeouts) of the raft implementation behave in the expected way.